### PR TITLE
Fix build for 2.071.2 and some early fixes for 2.072

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ dist: trusty
 language: d
 
 d:
- - dmd
+ - dmd-2.071.2
 
 # Ruby is needed to build the Jekyll docs
 before_install:

--- a/source/button/build.d
+++ b/source/button/build.d
@@ -460,10 +460,10 @@ void checkRaces(Graph!(Resource, Task) graph)
     }
 
     throw new BuildException(
-        "Found %d race conditions:\n"
-        "%s\n"
-        "Use `button graph` to see which tasks they are."
-        .format(
+        format(
+            "Found %d race conditions:\n" ~
+                "%s\n" ~
+                "Use `button graph` to see which tasks they are.",
             races.length,
             races.map!(r => " * `%s` is an output of %d tasks".format(r[0], r[1]))
                  .joiner("\n")

--- a/source/button/watcher/inotify.d
+++ b/source/button/watcher/inotify.d
@@ -75,9 +75,9 @@ struct ChangeChunks
 
     this(BuildState state, string watchDir, size_t delay)
     {
-        import std.path : filenameCmp, dirName;
+        import std.path : filenameCmp, dirName, buildNormalizedPath;
         import std.container.rbtree;
-        import std.file : exists, buildNormalizedPath;
+        import std.file : exists;
         import core.sys.linux.sys.inotify;
         import io.file.stream : sysEnforce;
         import std.conv : to;


### PR DESCRIPTION
Full compatibility with 2.072 looks rather challenging right now because that release clearly lacked testing and is too eager with breaking things. It probably makes sense to wait for 2.072.1 before upgrading to it.