### PR TITLE
Detect changes to directories, not just files

### DIFF
--- a/source/button/deps.d
+++ b/source/button/deps.d
@@ -13,14 +13,15 @@ import button.resource;
 align(4) struct Dependency
 {
     /**
-     * Timestamp of the resource. If unknown, this should be set to 0. In such a
-     * case, the parent build system will compute the value when needed. This is
-     * used by the parent build system to determine if the checksum needs to be
-     * recomputed.
+     * Status of the resource.
      *
-     * For files and directories, this is its last modification time.
+     * Can be:
+     *  0: Status is unknown.
+     *  1: Resource does not exist.
+     *  2: The resource is a file.
+     *  3: The resource is a directory.
      */
-    ulong timestamp;
+    uint status;
 
     /**
      * SHA-256 checksum of the contents of the resource. If unknown or not
@@ -50,7 +51,7 @@ align(4) struct Dependency
 
 unittest
 {
-    static assert(Dependency.sizeof == 44);
+    static assert(Dependency.sizeof == 40);
 }
 
 /**
@@ -103,7 +104,7 @@ struct Deps
 
         _current = Resource(
             name,
-            SysTime(cast(long)dep.timestamp),
+            cast(Resource.Status)dep.status,
             dep.checksum
             );
 


### PR DESCRIPTION
Before if a task depended on a directory (i.e., the list of files it contains), then it would not get re-run if the directory contents changed.

Now, if a resource is a directory, then we take the checksum of the file list for later comparison. Furthermore, comparing the timestamps of the directory itself is unreliable. If a file is deleted from a directory, the directory's timestamp is not updated. Thus, in the interest of correctness, the comparison of timestamps of both files and directories is now removed. This may have some impact on performance for large codebases. However, eventually a daemon to collect changes should be run in the background instead to help alleviate this issue.