### PR TITLE
Remove cyclic module dependencies / support 2.072.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ language: d
 
 d:
  - dmd-2.071.2
+ - dmd-2.072.1
 
 # Ruby is needed to build the Jekyll docs
 before_install:

--- a/source/button/app.d
+++ b/source/button/app.d
@@ -7,6 +7,7 @@
  * Program entry point.
  */
 import button.cli;
+import button.exceptions;
 
 import std.meta : AliasSeq;
 

--- a/source/button/build.d
+++ b/source/button/build.d
@@ -21,6 +21,7 @@ import button.rule;
 import button.log;
 import button.context;
 import button.exceptions;
+import button.handler;
 
 alias BuildStateGraph = Graph!(
         Index!Resource,

--- a/source/button/build.d
+++ b/source/button/build.d
@@ -20,6 +20,7 @@ import button.textcolor;
 import button.rule;
 import button.log;
 import button.context;
+import button.exceptions;
 
 alias BuildStateGraph = Graph!(
         Index!Resource,
@@ -27,17 +28,6 @@ alias BuildStateGraph = Graph!(
         EdgeType,
         EdgeType,
         );
-
-/**
- * An exception relating to the build.
- */
-class BuildException : Exception
-{
-    this(string msg)
-    {
-        super(msg);
-    }
-}
 
 /**
  * Constructs the name of the build state file based on the build description

--- a/source/button/cli/build.d
+++ b/source/button/cli/build.d
@@ -24,6 +24,7 @@ import button.textcolor;
 import button.log;
 import button.watcher;
 import button.context;
+import button.exceptions;
 
 /**
  * Returns a build logger based on the command options.

--- a/source/button/cli/clean.d
+++ b/source/button/cli/clean.d
@@ -16,7 +16,8 @@ import button.state,
        button.rule,
        button.graph,
        button.build,
-       button.textcolor;
+       button.textcolor,
+       button.exceptions;
 
 /**
  * Deletes outputs.

--- a/source/button/cli/convert.d
+++ b/source/button/cli/convert.d
@@ -15,6 +15,7 @@ import button.cli.options : ConvertOptions, ConvertFormat, GlobalOptions;
 import button.build;
 import button.resource;
 import button.task;
+import button.exceptions;
 
 import io.file, io.text;
 

--- a/source/button/cli/gc.d
+++ b/source/button/cli/gc.d
@@ -16,7 +16,8 @@ import button.state,
        button.rule,
        button.graph,
        button.build,
-       button.textcolor;
+       button.textcolor,
+       button.exceptions;
 
 /**
  * Collects garbage.

--- a/source/button/cli/graph.d
+++ b/source/button/cli/graph.d
@@ -20,7 +20,8 @@ import button.resource,
        button.edgedata,
        button.graph,
        button.state,
-       button.build;
+       button.build,
+       button.exceptions;
 
 int graphCommand(GraphOptions opts, GlobalOptions globalOpts)
 {

--- a/source/button/cli/options.d
+++ b/source/button/cli/options.d
@@ -12,6 +12,8 @@ import std.meta : AliasSeq;
 
 import darg;
 
+import button.exceptions;
+
 struct Command
 {
     string name;
@@ -256,17 +258,6 @@ alias OptionsList = AliasSeq!(
         GCOptions,
         ConvertOptions,
         );
-
-/**
- * Thrown when an invalid command name is given to $(D runCommand).
- */
-class InvalidCommand : Exception
-{
-    this(string msg)
-    {
-        super(msg);
-    }
-}
 
 /**
  * Using the list of command functions, runs a command from the specified

--- a/source/button/cli/status.d
+++ b/source/button/cli/status.d
@@ -23,6 +23,7 @@ import button.resource;
 import button.state;
 import button.build;
 import button.textcolor;
+import button.exceptions;
 
 int statusCommand(StatusOptions opts, GlobalOptions globalOpts)
 {

--- a/source/button/command.d
+++ b/source/button/command.d
@@ -6,25 +6,9 @@
 module button.command;
 
 import button.log;
+import button.exceptions;
 import button.resource;
 import button.context;
-
-/**
- * Thrown if a command fails.
- */
-class CommandError : Exception
-{
-    int exitCode;
-
-    this(int exitCode)
-    {
-        import std.format : format;
-
-        super("Command failed with exit code %d".format(exitCode));
-
-        this.exitCode = exitCode;
-    }
-}
 
 /**
  * Escapes the argument according to the rules of bash, the most commonly used

--- a/source/button/command.d
+++ b/source/button/command.d
@@ -162,29 +162,4 @@ struct Command
     {
         return args[0];
     }
-
-    /**
-     * Executes the command.
-     */
-    Result execute(ref BuildContext ctx, string workDir, TaskLogger logger) const
-    {
-        import std.path : buildPath;
-        import std.datetime : StopWatch, AutoStart;
-        import button.handler : executeHandler = execute;
-
-        auto inputs  = Resources(ctx.root, workDir);
-        auto outputs = Resources(ctx.root, workDir);
-
-        auto sw = StopWatch(AutoStart.yes);
-
-        executeHandler(
-                ctx,
-                args,
-                buildPath(ctx.root, workDir),
-                inputs, outputs,
-                logger
-                );
-
-        return Result(inputs.data, outputs.data, sw.peek());
-    }
 }

--- a/source/button/exceptions.d
+++ b/source/button/exceptions.d
@@ -11,15 +11,14 @@
  */
 module button.exceptions;
 
+import std.exception : basicExceptionCtors;
+
 /**
  * Thrown when an invalid command name is given to $(D runCommand).
  */
 class InvalidCommand : Exception
 {
-    this(string msg)
-    {
-        super(msg);
-    }
+    mixin basicExceptionCtors;
 }
 
 /**
@@ -29,11 +28,11 @@ class CommandError : Exception
 {
     int exitCode;
 
-    this(int exitCode)
+    this(int exitCode, string file = __FILE__, int line = __LINE__)
     {
         import std.format : format;
 
-        super("Command failed with exit code %d".format(exitCode));
+        super("Command failed with exit code %d".format(exitCode), file, line);
 
         this.exitCode = exitCode;
     }
@@ -44,11 +43,7 @@ class CommandError : Exception
  */
 class MakeParserError : Exception
 {
-    this(string msg)
-    {
-        // TODO: Include line information?
-        super(msg);
-    }
+    mixin basicExceptionCtors;
 }
 
 /**
@@ -56,10 +51,7 @@ class MakeParserError : Exception
  */
 class InvalidEdge : Exception
 {
-    this(string msg, string file = __FILE__, size_t line = __LINE__)
-    {
-        super(msg, file, line);
-    }
+    mixin basicExceptionCtors;
 }
 
 /**
@@ -67,10 +59,7 @@ class InvalidEdge : Exception
  */
 class BuildException : Exception
 {
-    this(string msg)
-    {
-        super(msg);
-    }
+    mixin basicExceptionCtors;
 }
 
 /**
@@ -78,8 +67,5 @@ class BuildException : Exception
  */
 class TaskError : Exception
 {
-    this(string msg)
-    {
-        super(msg);
-    }
+    mixin basicExceptionCtors;
 }

--- a/source/button/exceptions.d
+++ b/source/button/exceptions.d
@@ -1,0 +1,85 @@
+/**
+ * Copyright: Copyright Jason White, 2016
+ * License:   MIT
+ * Authors:   Jason White
+ *
+ * Description:
+ * Defines exception classes used in button
+ *
+ * Definitions of exception classes are separated into own module
+ * to break module import cycles and reduce overall module inter-depdendency
+ */
+module button.exceptions;
+
+/**
+ * Thrown when an invalid command name is given to $(D runCommand).
+ */
+class InvalidCommand : Exception
+{
+    this(string msg)
+    {
+        super(msg);
+    }
+}
+
+/**
+ * Thrown if a command fails.
+ */
+class CommandError : Exception
+{
+    int exitCode;
+
+    this(int exitCode)
+    {
+        import std.format : format;
+
+        super("Command failed with exit code %d".format(exitCode));
+
+        this.exitCode = exitCode;
+    }
+}
+
+/**
+ * Exception that is thrown on invalid GCC deps syntax.
+ */
+class MakeParserError : Exception
+{
+    this(string msg)
+    {
+        // TODO: Include line information?
+        super(msg);
+    }
+}
+
+/**
+ * Thrown when an edge does not exist.
+ */
+class InvalidEdge : Exception
+{
+    this(string msg, string file = __FILE__, size_t line = __LINE__)
+    {
+        super(msg, file, line);
+    }
+}
+
+/**
+ * An exception relating to the build.
+ */
+class BuildException : Exception
+{
+    this(string msg)
+    {
+        super(msg);
+    }
+}
+
+/**
+ * Thrown if a task fails.
+ */
+class TaskError : Exception
+{
+    this(string msg)
+    {
+        super(msg);
+    }
+}

--- a/source/button/handlers/base.d
+++ b/source/button/handlers/base.d
@@ -65,7 +65,7 @@ void execute(
     import std.array : array;
 
     import button.deps : deps;
-    import button.command : CommandError;
+    import button.exceptions : CommandError;
 
     int[2] stdfds, inputfds, outputfds;
 

--- a/source/button/handlers/gcc.d
+++ b/source/button/handlers/gcc.d
@@ -12,6 +12,7 @@
 module button.handlers.gcc;
 
 import button.log;
+import button.exceptions;
 import button.resource;
 import button.context;
 
@@ -19,18 +20,6 @@ import std.range.primitives : isInputRange, ElementEncodingType,
                               front, empty, popFront;
 
 import std.traits : isSomeChar;
-
-/**
- * Exception that is thrown on invalid GCC deps syntax.
- */
-class MakeParserError : Exception
-{
-    this(string msg)
-    {
-        // TODO: Include line information?
-        super(msg);
-    }
-}
 
 /**
  * Helper function to escape a character.

--- a/source/button/state.d
+++ b/source/button/state.d
@@ -9,6 +9,7 @@
 module button.state;
 
 import button.command;
+import button.exceptions;
 import button.resource;
 import button.task;
 import button.edge, button.edgedata;
@@ -179,17 +180,6 @@ alias Other(A : Task) = Resource; /// Ditto
  * Convenience template to construct an edge from the starting vertex.
  */
 alias NeighborIndex(V : Index!V) = EdgeIndex!(V, Other!V);
-
-/**
- * Thrown when an edge does not exist.
- */
-class InvalidEdge : Exception
-{
-    this(string msg, string file = __FILE__, size_t line = __LINE__)
-    {
-        super(msg, file, line);
-    }
-}
 
 /**
  * Deserializes a vertex from a SQLite statement. This assumes that the

--- a/source/button/task.d
+++ b/source/button/task.d
@@ -193,27 +193,4 @@ struct Task
         assert(Task([["a", "b"]], "b") >  Task([["a", "b"]], "a"));
         assert(Task([["a", "b"]], "a") == Task([["a", "b"]], "a"));
     }
-
-    Result execute(ref BuildContext ctx, TaskLogger logger)
-    {
-        import std.array : appender;
-
-        // FIXME: Use a set instead?
-        auto inputs  = appender!(Resource[]);
-        auto outputs = appender!(Resource[]);
-
-        foreach (command; commands)
-        {
-            auto result = command.execute(ctx, workingDirectory, logger);
-
-            // FIXME: Commands may have temporary inputs and outputs. For
-            // example, if one command creates a file and a later command
-            // deletes it, it should not end up in either of the input or output
-            // sets.
-            inputs.put(result.inputs);
-            outputs.put(result.outputs);
-        }
-
-        return Result(inputs.data, outputs.data);
-    }
 }

--- a/source/button/task.d
+++ b/source/button/task.d
@@ -9,17 +9,7 @@ import button.command;
 import button.log;
 import button.resource;
 import button.context;
-
-/**
- * Thrown if a task fails.
- */
-class TaskError : Exception
-{
-    this(string msg)
-    {
-        super(msg);
-    }
-}
+import button.exceptions;
 
 /**
  * A task key must be unique.


### PR DESCRIPTION
In DMD 2.072.1 cyclic module detection was fixed, resulting in bunch of runtime errors like this:

```
object.Error@src/rt/minfo.d(356): Cyclic dependency between module button.handlers.base and button.handler
button.handlers.base* ->
button.context ->
button.state ->
button.command ->
button.handler* ->
button.handlers ->
button.handlers.base*
```

It can be disabled by running as `button --DRT-oncycle=ignore build` so the breakage is not critical but it is quite annoying and avoiding import cycles is a good thing on its own anyway. This PR does bunch of refactorings to address the issue and enables 2.072.1 in travis.