### PR TITLE
Improve reported error message for malformed JSON

### DIFF
--- a/source/button/build.d
+++ b/source/button/build.d
@@ -159,11 +159,19 @@ Rules rules(string path)
     import button.rule;
 
     import std.exception : ErrnoException;
+    import std.json : JSONException;
+    import std.string : format;
 
     try
     {
         auto r = File(path).byBlock!char;
         return parseRules(&r);
+    }
+    catch (JSONException e)
+    {
+        throw new BuildException(
+            format("Malformed build description ('%s'): '%s'", path, e.msg)
+        );
     }
     catch (ErrnoException e)
     {


### PR DESCRIPTION
Before:

```
$ button build
:: Build failed! See the output above for details.
```

After:

```
$ button build
:: Error: Malformed build description ('.button-generated.json'): 'JSONValue is not an array'
````