### PR TITLE
Print build failure exception in verbose mode

### DIFF
--- a/source/button/cli/build.d
+++ b/source/button/cli/build.d
@@ -130,6 +130,9 @@ int doBuild(ref BuildContext ctx, string path)
         stderr.println(ctx.color.status, ":: ", ctx.color.error,
                 "Build failed!", ctx.color.reset,
                 " See the output above for details.");
+        if (ctx.verbose)
+            println(ctx.color.status, ":: ", e.toString());
+
         return 1;
     }
 


### PR DESCRIPTION
Trivial change that will hopefully help me to track some real usability issues :)

Despite original intention of having explanatory output in previous
build log, it is still possible to get mysterious "build failed" errors
with no details before. Printing exception details in verbose mode will
help to track them down and fix.